### PR TITLE
Adding default value for settings.

### DIFF
--- a/system/expressionengine/third_party/gathercontent/ext.gathercontent.php
+++ b/system/expressionengine/third_party/gathercontent/ext.gathercontent.php
@@ -34,6 +34,7 @@ class Gathercontent_ext {
 	        'class'     => __CLASS__,
 	        'method'    => 'delete_file',
 	        'hook'      => 'files_after_delete',
+	        'settings'  => '',
 	        'priority'  => 10,
 	        'version'   => $this->version,
 	        'enabled'   => 'y'


### PR DESCRIPTION
Using EE version 2.10.1, installation fails:

```
A Database Error Occurred
Error Number: 1364

Field 'settings' doesn't have a default value

INSERT INTO `dcnr_extensions` (`class`, `method`, `hook`, `priority`, `version`, `enabled`) VALUES ('Gathercontent_ext', 'delete_file', 'files_after_delete', 10, '1.0', 'y')

Filename: third_party/gathercontent/ext.gathercontent.php

Line Number: 42
```

I added default value for settings so that extension will install successfully.
